### PR TITLE
do not escape html in registartion views

### DIFF
--- a/plugins/registration/app/views/registration/create.json.erb
+++ b/plugins/registration/app/views/registration/create.json.erb
@@ -1,1 +1,1 @@
-<%= @register.to_json if @register -%>
+<%= @register.to_json.html_safe if @register -%>

--- a/plugins/registration/app/views/registration/create.xml.erb
+++ b/plugins/registration/app/views/registration/create.xml.erb
@@ -1,1 +1,1 @@
-<%= @register.to_xml if @register -%>
+<%= @register.to_xml.html_safe if @register -%>

--- a/plugins/registration/app/views/registration/show.json.erb
+++ b/plugins/registration/app/views/registration/show.json.erb
@@ -1,1 +1,1 @@
-<%= @register.to_json if @register -%>
+<%= @register.to_json.html_safe if @register -%>

--- a/plugins/registration/app/views/registration/show.xml.erb
+++ b/plugins/registration/app/views/registration/show.xml.erb
@@ -1,1 +1,1 @@
-<%= @register.to_xml if @register -%>
+<%= @register.to_xml.html_safe if @register -%>


### PR DESCRIPTION
By the default rails escapes content in html. That creates a
problem when this html is in a view used for creating responses to
webservices.
In order to avoid this, we need to use html_safe in the views
for json and xml.
