### PR TITLE
read_status is an instance member

### DIFF
--- a/plugins/registration/app/models/register.rb
+++ b/plugins/registration/app/models/register.rb
@@ -260,7 +260,7 @@ public
     newconfig = { 'regserverurl' => registrationserver,
                   'regserverca'  => certificate  }
     ret = YastService.Call("YSR::setregistrationconfig", newconfig)
-    self.read_status
+    read_status
     return ret
   end
 


### PR DESCRIPTION
please apply this patch.  Otherwise it gives 

Uncaught exception NoMethodError: private method `read_status' called for #Register:0x7f3dee8f3dc8
