### PR TITLE
explicitelly check regex for email adrress to prevent sheel escaping

### DIFF
--- a/plugins/mailsetting/app/controllers/mailsetting_controller.rb
+++ b/plugins/mailsetting/app/controllers/mailsetting_controller.rb
@@ -61,7 +61,7 @@ public
 
     if params.has_key? :send_mail
       if request.format.html?
-        if mail_params[:test_mail_address].to_s.match(/\A[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]+\z/)
+        if Mailsetting.valid_mail_address?(mail_params[:test_mail_address])
           Mailsetting.send_test_mail mail_params[:test_mail_address]
           flash[:notice] = _("A test message has been sent to email address %s") % mail_params[:test_mail_address]
           redirect_to :action => "show", :email => mail_params[:test_mail_address].to_s

--- a/plugins/mailsetting/app/models/mailsetting.rb
+++ b/plugins/mailsetting/app/models/mailsetting.rb
@@ -76,15 +76,19 @@ class Mailsetting < BaseModel::Base
     true
   end
 
+  def self.valid_mail_address? (address)
+    return !!address.match(/\A[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]+\z/)
+  end
+
   def self.send_test_mail(to)
-    return if to.nil? || to.empty?
+    return if to.blank?
 
     Rails.logger.debug "sending test mail to #{to}..."
 
     message	= "This is the test mail sent to you by webYaST."
 
     # remove potential problematic characters from email address
-    to.tr!("~'\"<>","")
+    raise "Invalid email address" unless valid_mail_address?(to)
     `/bin/echo "#{message}" | /bin/mail -s "WebYaST Test Mail" '#{to}' -r root`
 
     mail_directory = File.join(YaST::Paths::VAR,"mailsetting")


### PR DESCRIPTION
I change it to be there explicit regexp that prevent to pass dangerous strings to CLI.
