### PR TITLE
Use the old SSL certificates when updating from previous release

### DIFF
--- a/webyast/package/webyast-base.spec
+++ b/webyast/package/webyast-base.spec
@@ -364,6 +364,12 @@ if /bin/rpm -q webyast-base-ui > /dev/null ; then
       echo "/usr/sbin/rcwebyast restart" >> %name-%version-%release-1
     fi
   fi
+
+  # move the current SSL certificates to the new location
+  if [ -f /etc/lighttpd/certs/webyast.pem ]; then
+    mkdir -p /etc/nginx/certs
+    mv /etc/lighttpd/certs/webyast* /etc/nginx/certs
+  fi
 fi
 #We are switching from lighttpd to nginx. So lighttpd has to be killed
 #at first


### PR DESCRIPTION
The certificate location has been changed, after update from 1.2 webyast regenerates new SSL certificates as fallback. This can confuse users as the certificates will not be trusted by browser after change.
