### PR TITLE
fix passing checkbox value to controller

### DIFF
--- a/plugins/activedirectory/app/views/activedirectory/show.html.erb
+++ b/plugins/activedirectory/app/views/activedirectory/show.html.erb
@@ -73,7 +73,7 @@
       <div class="fieldset_header">
         <span class="fieldset_header_title" >
           <%= _("Enable Authentication of AD users") %>
-          <%= check_box 'activedirectory', :enabled, {:disabled => disabled, :checked => @activedirectory.enabled}, true,false -%>
+          <%= check_box 'activedirectory', :enabled, {:disabled => disabled, :checked => @activedirectory.enabled}, "true","false" -%>
         </span>
       </div>
 

--- a/plugins/kerberos/app/controllers/kerberos_controller.rb
+++ b/plugins/kerberos/app/controllers/kerberos_controller.rb
@@ -54,6 +54,7 @@ class KerberosController < ApplicationController
         @kerberos.load params[:kerberos]
         #translate from text to boolean
         @kerberos.enabled = params[:kerberos][:enabled] == "true"
+        @kerberos.dns_used = params[:kerberos][:use_dns] == "true"
       else
         @kerberos.enabled = false
       end

--- a/plugins/kerberos/app/views/kerberos/index.html.erb
+++ b/plugins/kerberos/app/views/kerberos/index.html.erb
@@ -97,14 +97,14 @@
       <div class="fieldset_header">
         <span class="fieldset_header_title" >
           <%= _("Enable Kerberos Authentication") %>
-          <%= check_box 'kerberos', :enabled, {:disabled => disabled, :checked => @kerberos.enabled}, true,false -%>
+          <%= check_box 'kerberos', :enabled, {:disabled => disabled, :checked => @kerberos.enabled}, "true","false" -%>
         </span>
       </div>
 
       <div class="fieldset_body">
         <div class="row">
           <%# FIME: move the style to a separate CSS file %>
-          <%= check_box 'kerberos', :use_dns, {:disabled => disabled, :checked => @kerberos.dns_used, :style => "width: auto; vertical-align: middle;"}, true, false %>
+          <%= check_box 'kerberos', :use_dns, {:disabled => disabled, :checked => @kerberos.dns_used, :style => "width: auto; vertical-align: middle;"}, "true", "false" %>
           <%= label_tag :kerberos_use_dns, _("Use Kerberos configuration from DNS server"), :style => "width: auto; vertical-align: middle;", :title => _("If checked the Kerberos configuration will be read from DNS server at runtime instead of using the preconfigured values below."), :class => "tipsy_help" %>
         </div>
 

--- a/plugins/ldap/app/views/ldap/index.html.erb
+++ b/plugins/ldap/app/views/ldap/index.html.erb
@@ -116,7 +116,7 @@
       <div class="fieldset_header">
         <span class="fieldset_header_title" >
           <%= _("Enable LDAP Authentication") %>
-          <%= check_box 'ldap', :enabled, {:disabled => disabled, :checked => @ldap.enabled}, true,false -%>
+          <%= check_box 'ldap', :enabled, {:disabled => disabled, :checked => @ldap.enabled}, "true", "false" -%>
         </span>
       </div>
 
@@ -138,7 +138,7 @@
    
         <div class="row">
           <label><%= _("Secure Connection") %></label>
-          <%= check_box 'ldap', :tls, {:disabled => disabled, :checked => @ldap.tls, :style=>"margin-left:-1px;" }, true,false -%>
+          <%= check_box 'ldap', :tls, {:disabled => disabled, :checked => @ldap.tls, :style=>"margin-left:-1px;" }, "true", "false" -%>
         </div>
       </div>
     </fieldset>

--- a/plugins/time/app/views/time/index.html.erb
+++ b/plugins/time/app/views/time/index.html.erb
@@ -175,7 +175,7 @@
 
             <div class="time_subsection">
             <div class="row check_row">
-              <%= check_box 'time', :set_time, {:disabled => disabled, :checked => false}, true, false %>
+              <%= check_box 'time', :set_time, {:disabled => disabled, :checked => false} %>
               <%= label_tag :time_set_time, _("Set the current date and time") %>
             </div>
 


### PR DESCRIPTION
Reason to this change is that rails have new feature, that
unchecked value (last value for check_box helper) is evaluated
and if it is false, it doesn't generate unchecked value and it is not
passed at all to controller.

Previous behavior was to pass just value.to_s, so I manually change
values from true,false to "true,"false" that is always true and same as
previous to_s behavior.

There is two exceptions:
1) in time checkbox is used only for javascript, so it doesn't need
special values and I remove it to kept defaults
2) in kerberos I add special handling for use_dns as it doesn't match
dns_used value in model. Looks like relict from from server merge and
because it is used by javascript and model use name from ycp I don't
want to break it and add just translation.
