### PR TITLE
Fixed creating bond interface (slaves)

### DIFF
--- a/plugins/network/app/views/network/_form.html.erb
+++ b/plugins/network/app/views/network/_form.html.erb
@@ -114,7 +114,8 @@
           <label class="tvalign"><%=_("Bond slaves")%></label>
           <div class="checkbox_container">
             <% @ifcs.each do |id, iface| %>
-              <% next if id.match("bond") || iface.bootproto!="none" %>
+              <%# Offering only interfaces that are not configured or have empty configuration %>
+              <% next if id.match("bond") || (iface.bootproto && iface.bootproto!="none") %>
               <div>
                 <%= check_box :bond_slaves, id, :checked => (@ifc.bond_slaves.is_a?(String) ? @ifc.bond_slaves.split(" ") : @ifc.bond_slaves).include?(id) %>
                 <%= id %> <%= "- #{iface.vendor}" if iface.vendor %>


### PR DESCRIPTION
- Slaves can be only interfaces with bootproto=none but WebYast
  handles 'no configuration' the same way
- If interface that has no configuration is used, it has to be
  configuredd with bootproto=none later
- This is WIP but can be merged right now
