### PR TITLE
Roles - fixed restdoc

### DIFF
--- a/plugins/roles/restdoc/api.txt
+++ b/plugins/roles/restdoc/api.txt
@@ -7,8 +7,6 @@
   Only authenticated users are allowed to access the API. Authentication is done
   by sending a Basic HTTP Authorization header.
 
-== Table of Contents
-
 Contents
 
 == Overview


### PR DESCRIPTION
- XmlBody tags were not rendered properly (there must be _single_ space delimiter)
- "<", ">" were not escaped
- use <hostname> instead of localhost
- use https protocol
- arguments need to start at the line beginning (no spaces at the beginning)
- added new title (displayed in the content)
- removed <password> option (passing password on commandline is not secure)
- added empty lines at the end of the file (without them the last line was lost)
- removed duplicated "Table of Contents" headline
  
  (well, it seems that restdoc has some bugs...)
