### PR TITLE
Updated REST API documentation (bnc#790159)

### DIFF
--- a/plugins/software/package/rubygem-webyast-software.changes
+++ b/plugins/software/package/rubygem-webyast-software.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Feb 25 13:06:09 UTC 2013 - lslezak@suse.cz
+
+- updated REST API documentation (patch installation) (bnc#790159)
+- 0.3.37
+
+-------------------------------------------------------------------
 Wed Feb 20 11:44:07 UTC 2013 - lslezak@suse.cz
 
 - fixed REST API (bnc#790159)

--- a/plugins/software/package/rubygem-webyast-software.spec
+++ b/plugins/software/package/rubygem-webyast-software.spec
@@ -17,7 +17,7 @@
 
 
 Name:           rubygem-webyast-software
-Version:        0.3.36
+Version:        0.3.37
 Release:        0
 %define mod_name webyast-software
 %define mod_full_name %{mod_name}-%{version}

--- a/plugins/software/restdoc/api.txt
+++ b/plugins/software/restdoc/api.txt
@@ -14,7 +14,7 @@
   by sending a Basic HTTP Authorisation header, authentication cookie or using
   token authentication.
 
-== Table of Contents
+Contents
 
 == Formats
 
@@ -42,7 +42,7 @@
 
 GET /patches
 
-  Return all available or installed patches (the status is set in "installed" value)
+  Return all available and recently installed patches (the status is set in "installed" value)
 
   CURL Example: curl -u &lt;user&gt; https://&lt;hostname&gt;:4984/patches.xml
 
@@ -60,12 +60,12 @@ GET /patches/patch_id.xml
 XmlResult: patch
 
 
-POST /patches/patch_id.xml
+POST /patches/install/patch_id.xml
 
   Install the patch with given ID. Patch installation runs in background, the response code is 202 Accepted when patch installation started.
   Then the patch index has to be queried to get the actual patch installation result.
 
-  CURL example: curl -u &lt;user&gt; -X POST 'https://&lt;hostname&gt;:4984/patches/slessp2-PackageKit;7256;noarch;nu_novell_com:SLES11-SP2-Updates.xml'
+  CURL example: curl -u &lt;user&gt; -X POST 'https://&lt;hostname&gt;:4984/patches/install/slessp2-PackageKit;7256;noarch;nu_novell_com:SLES11-SP2-Updates.xml'
 
 
 == Repository Management Actions

--- a/plugins/software/webyast-software.gemspec
+++ b/plugins/software/webyast-software.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = "webyast-software"
-  s.version = "0.3.36"
+  s.version = "0.3.37"
   s.authors = ["WebYaST team"]
   s.summary = "Webyast module for handling patches and repos"
   s.email = "yast-devel@opensuse.org"


### PR DESCRIPTION
- patch installation is done via POST /patches/install/patch_id.xml
- properly render Contents
- better description for GET /patches.xml
- 0.3.37
