### PR TITLE
Require pam-modules in webyast-base | bnc#811196

### DIFF
--- a/webyast/package/webyast-base.spec
+++ b/webyast/package/webyast-base.spec
@@ -61,9 +61,10 @@ Requires:       nginx >= 1.0.15
 Requires:       rubygem-ruby-dbus
 Requires:       syslog
 Requires:       yast2-dbus-server
-
 Requires:       rubygem-webyast-rake-tasks >= 0.3.5
 Requires:       webyast-base-branding
+Requires:       pam-modules
+
 PreReq:         rubygem-bundler
 # 634404
 Recommends:     logrotate


### PR DESCRIPTION
Avoid error `No such file or directory - /sbin/unix2_chkpwd` on login.

Relevant bugs:
- bnc#809579
- bnc#811196
