### PR TITLE
eulas, mailsetting - do not change attributes of /var/lib/webyast/

### DIFF
--- a/plugins/eulas/package/rubygem-webyast-eulas.spec
+++ b/plugins/eulas/package/rubygem-webyast-eulas.spec
@@ -152,7 +152,6 @@ rm -rf $RPM_BUILD_ROOT/%{_libdir}/ruby/gems/%{rb_ver}/gems/%{mod_full_name}/publ
 %{webyast_dir}/public/assets/*
 %dir /usr/share/%{webyast_user}
 %dir /usr/share/%{webyast_user}/%{plugin_name}
-%dir %{webyast_vardir}
 %dir %{webyast_vardir}/%{plugin_name}
 /usr/share/%{webyast_user}/%{plugin_name}/licenses
 %dir /etc/webyast/

--- a/plugins/mailsetting/package/rubygem-webyast-mailsetting.spec
+++ b/plugins/mailsetting/package/rubygem-webyast-mailsetting.spec
@@ -160,7 +160,6 @@ install -m 0755 %SOURCE3 $RPM_BUILD_ROOT/etc/sysconfig/network/scripts/
 %dir /usr/share/YaST2/modules/
 %dir /usr/share/YaST2/modules/YaPI/
 #var dir to store mail test status
-%dir %attr (-,%{webyast_user},root) %{webyast_vardir}
 %dir %attr (-,%{webyast_user},root) %{webyast_vardir}/mailsetting
 
 /usr/share/YaST2/modules/YaPI/MailSettings.pm


### PR DESCRIPTION
the permissions are set in webyast-base, avoid conflicts with that package

Reported by OBS checks, see
- https://build.opensuse.org/request/show/187274
- https://build.opensuse.org/request/show/187278
