### PR TITLE
Gemfile - optionally skip loading WebYast gems

### DIFF
--- a/webyast-tasks/package/macros.webyast
+++ b/webyast-tasks/package/macros.webyast
@@ -87,7 +87,7 @@
     export RAILS_PARENT=%{webyast_dir} \
     cd $RPM_BUILD_ROOT/%{_libdir}/ruby/gems/%{rb_ver}/gems/%{mod_full_name} \
     cp /srv/www/webyast/Gemfile.assets . \
-    BUNDLE_GEMFILE=Gemfile.assets bundle exec rake assets:precompile \
+    WEBYAST_LOAD_GEMS=false BUNDLE_GEMFILE=Gemfile.assets bundle exec rake assets:precompile \
     rm -f Gemfile.assets Gemfile.assets.lock \
     rm -rf tmp \
     mkdir -p $RPM_BUILD_ROOT/srv/www/webyast/public/assets \

--- a/webyast/Gemfile
+++ b/webyast/Gemfile
@@ -36,20 +36,22 @@ else
   gem 'polkit1'
 end
 
-plugin_path = File.expand_path("../../plugins",  __FILE__)
-gemspecs = Dir.glob(File.join(plugin_path, "**", "*.gemspec"))
+if ENV["WEBYAST_LOAD_GEMS"] != "false"
+  plugin_path = File.expand_path("../../plugins",  __FILE__)
+  gemspecs = Dir.glob(File.join(plugin_path, "**", "*.gemspec"))
 
-unless gemspecs.empty?
-  #We are in devel. mode. Loading all plugins
-  gemspecs.each do |gemspec|
-    plugin_name = gemspec.split("/").pop.split(".").first
-    gem plugin_name, :path => File.expand_path("../../plugins/#{gemspec.split("/").pop(2).first}", __FILE__)
-  end
-else
-  #Loading webyast gems from the gem path
-  Dir.glob(Gem.default_path.map{|p| File.join(p, "gems/webyast-*")}).each do |pth|
-    # get gem name from path: /usr/lib64/ruby/gems/1.8/gems/webyast-users-0.1 => webyast-users
-    gem File.basename(pth).split("-")[0..-2].join("-")
+  if !gemspecs.empty?
+    # Loading webyast gems from the gem path
+    Dir.glob(Gem.default_path.map{|p| File.join(p, "gems/webyast-*")}).each do |pth|
+      # get gem name from path: /usr/lib64/ruby/gems/1.8/gems/webyast-users-0.1 => webyast-users
+      gem File.basename(pth).split("-")[0..-2].join("-")
+    end
+  else
+    #We are in devel. mode. Loading all plugins
+    gemspecs.each do |gemspec|
+      plugin_name = gemspec.split("/").pop.split(".").first
+      gem plugin_name, :path => File.expand_path("../../plugins/#{gemspec.split("/").pop(2).first}", __FILE__)
+    end
   end
 end
 


### PR DESCRIPTION
needed by `rake assets:precompile` when building RPM package to avoid copying asset files from other packages (installed by BuildRequires dependencies).

Reported by OBS (see https://build.opensuse.org/request/show/187286) - `rubygem-webyast-time` contains files from `rubygem-webyast-services` which cause file conflicts.

(As a bonus the `unless ... else ...` has been changed to more readable `if ... else ...`.)
