### PR TITLE
Registration proxy fix

### DIFF
--- a/plugins/registration/app/controllers/registration_controller.rb
+++ b/plugins/registration/app/controllers/registration_controller.rb
@@ -426,6 +426,7 @@ public
     Rails.logger.debug "Registration arguments: #{arguments.inspect}"
     register.arguments = arguments
 
+    logger.info "Using default registration context: #{register.context.inspect}"
     begin
       params.each do | key, value |
         if key.starts_with? "registration_arg_"
@@ -440,8 +441,12 @@ public
     success = false
     begin
       context = params[:registration] ? params[:registration][:options] : {}
-      register.context = @options.merge context if context.is_a?(Hash)
+      logger.info "Context from parameters: #{context.inspect}"
+      logger.debug "options: #{@options.inspect}"
+      @options.merge context if context.is_a?(Hash)
+      register.context.merge(@options)
       Rails.logger.debug "Registration context: #{register.context.inspect}"
+      logger.info "Using Registration context: #{register.context.inspect}"
       exitcode = register.register
       logger.debug "registration finished: #{register.to_xml}"
 

--- a/plugins/registration/app/controllers/registration_controller.rb
+++ b/plugins/registration/app/controllers/registration_controller.rb
@@ -443,7 +443,7 @@ public
       context = params[:registration] ? params[:registration][:options] : {}
       logger.info "Context from parameters: #{context.inspect}"
       logger.debug "options: #{@options.inspect}"
-      @options.merge context if context.is_a?(Hash)
+      @options.merge(context) if context.is_a?(Hash)
       register.context.merge(@options)
       Rails.logger.debug "Registration context: #{register.context.inspect}"
       logger.info "Using Registration context: #{register.context.inspect}"

--- a/plugins/registration/app/models/register.rb
+++ b/plugins/registration/app/models/register.rb
@@ -97,6 +97,8 @@ public
     # read the configuration
     read_status
     # initialize context
+    Rails.logger.info "Initializing Register object with: #{hash.inspect}"
+
     init_context hash
   end
 
@@ -131,6 +133,7 @@ public
 
     # set proxy settings in context for suseRegister backend
     if proxy_config["PROXY_ENABLED"] && proxy_config["PROXY_ENABLED"].downcase == "yes"
+      Rails.logger.info "Proxy enabled"
       # check for NO_PROXY option
       if proxy_config["NO_PROXY"]
         # servers are comma separated
@@ -145,12 +148,16 @@ public
         end
       end
 
+      Rails.logger.info "proxy_config: #{proxy_config.inspect}"
       @context['proxy-http_proxy'] = proxy_config["HTTP_PROXY"] if proxy_config["HTTP_PROXY"]
       @context['proxy-https_proxy'] = proxy_config["HTTPS_PROXY"] if proxy_config["HTTPS_PROXY"]
+      Rails.logger.debug "Updated @context: #{@context.inspect}"
     end
 
     # last action: overwrite the context settings with the settings that were sent with the request
+    Rails.logger.debug "Context before merging: #{@context.inspect}"
     @context.merge! hash if hash.kind_of?(Hash)
+    Rails.logger.debug "Final context: #{@context.inspect}"
   end
 
   def is_registered?
@@ -162,6 +169,7 @@ public
     # don't know how to pass only one hash, so split it into two. TODO change later if possible!
     # @reg = YastService.Call("YSR::statelessregister", { 'ctx' => ctx, 'arguments' => args } )
 
+    Rails.logger.info "Registering with @context: #{@context.inspect}"
     ctx = Hash.new
     args = Hash.new
     begin

--- a/plugins/registration/package/rubygem-webyast-registration.changes
+++ b/plugins/registration/package/rubygem-webyast-registration.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Wed Dec 17 09:53:43 UTC 2014 - lslezak@suse.cz
+
+- fixed registration via a proxy server (bnc#908517)
+  (fixed merging the loaded config defaults (contains the proxy
+  config) with the user provided options - keep the unchanged
+  defaults, just rewrite the user provided values)
+- 0.3.18.2
+
+-------------------------------------------------------------------
 Wed May 15 12:27:19 UTC 2013 - lslezak@suse.cz
 
 - do not report unregistered system when SUSE Manager is used

--- a/plugins/registration/package/rubygem-webyast-registration.spec
+++ b/plugins/registration/package/rubygem-webyast-registration.spec
@@ -11,7 +11,7 @@
 
 # norootforbuild
 Name:           rubygem-webyast-registration
-Version:        0.3.18.1
+Version:        0.3.18.2
 Release:        0
 %define mod_name webyast-registration
 %define mod_full_name %{mod_name}-%{version}


### PR DESCRIPTION
The original code completely replaced the `register.context` value with the values received in the request. Unfortunately the original context also contains the proxy configuration (from `/etc/sysconfig/proxy`) which is then lost.

This fix merges the read values with the values sent by user (preferring the users values).

The fix has been tested in a customer's system (their setup allows network access only via proxy).
