### PR TITLE
Fixed possible Clickjacking vulnerability (bsc#981769)

### DIFF
--- a/webyast/app/controllers/application_controller.rb
+++ b/webyast/app/controllers/application_controller.rb
@@ -28,6 +28,7 @@ class ApplicationController < ActionController::Base
   before_filter :authenticate_account!
   before_filter :set_gettext_locale
   before_filter :base_system
+  after_filter  :headers
 
   protect_from_forgery
 
@@ -234,6 +235,15 @@ private
         end
       end
     end
+  end
+
+  # add custom HTTP headers
+  def headers
+    # tell the browser that it must not allow embedding this page to another
+    # page via an IFRAME, prevent from Clickjacking attacks
+    # see https://en.wikipedia.org/wiki/Clickjacking#Content_Security_Policy
+    # see https://www.troyhunt.com/clickjack-attack-hidden-threat-right-in/
+    response.headers["Content-Security-Policy"] = "frame-ancestors 'self'"
   end
 
 end

--- a/webyast/package/webyast-base.changes
+++ b/webyast/package/webyast-base.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Jun 10 08:09:37 UTC 2016 - lslezak@suse.cz
+
+- Fixed possible Clickjacking vulnerability (bsc#981769)
+- 0.3.43.3
+
+-------------------------------------------------------------------
 Tue Apr 21 08:12:37 UTC 2015 - lslezak@suse.cz
 
 - Explicitly load the YAML library before using it (bsc#926890)

--- a/webyast/package/webyast-base.spec
+++ b/webyast/package/webyast-base.spec
@@ -10,7 +10,7 @@
 
 
 Name:           webyast-base
-Version:        0.3.43.2
+Version:        0.3.43.3
 Release:        0
 Provides:       yast2-webservice = %{version}
 Obsoletes:      yast2-webservice < %{version}


### PR DESCRIPTION
- 0.3.43.3

The fix is fortunately easy, just tell the browser via an HTTP header that the page is not allowed to be embedded into an `IFRAME`.

See these links for more details:
- https://en.wikipedia.org/wiki/Clickjacking#Content_Security_Policy
- https://www.troyhunt.com/clickjack-attack-hidden-threat-right-in/

The fix has been successfully tested by the customer,
see bug https://bugzilla.suse.com/show_bug.cgi?id=981769.
